### PR TITLE
Better front-coding performance w/typed literals

### DIFF
--- a/hdt-api/src/main/java/org/rdfhdt/hdt/hdt/HDTVocabulary.java
+++ b/hdt-api/src/main/java/org/rdfhdt/hdt/hdt/HDTVocabulary.java
@@ -81,6 +81,7 @@ public class HDTVocabulary {
 	// Dictionary Types
 	public static final String DICTIONARY_TYPE_PLAIN = HDT_DICTIONARY_BASE+"Plain>";
 	public static final String DICTIONARY_TYPE_FOUR_SECTION = HDT_DICTIONARY_BASE+"Four>";
+	public static final String DICTIONARY_TYPE_FOUR_PSFC_SECTION = HDT_DICTIONARY_BASE+"FourPsfc>";
 
 	// Triples
 	public static final String TRIPLES_TYPE = DUBLIN_CORE+"format>";

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/DictionaryFactory.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/DictionaryFactory.java
@@ -30,6 +30,8 @@ package org.rdfhdt.hdt.dictionary;
 import org.rdfhdt.hdt.dictionary.impl.FourSectionDictionary;
 import org.rdfhdt.hdt.dictionary.impl.FourSectionDictionaryBig;
 import org.rdfhdt.hdt.dictionary.impl.HashDictionary;
+import org.rdfhdt.hdt.dictionary.impl.PSFCFourSectionDictionary;
+import org.rdfhdt.hdt.dictionary.impl.PSFCTempDictionary;
 import org.rdfhdt.hdt.exceptions.IllegalFormatException;
 import org.rdfhdt.hdt.hdt.HDTFactory;
 import org.rdfhdt.hdt.hdt.HDTVocabulary;
@@ -44,6 +46,7 @@ import org.rdfhdt.hdt.options.HDTSpecification;
 public class DictionaryFactory {
 
 	public static final String MOD_DICT_IMPL_HASH = "hash";
+	public static final String MOD_DICT_IMPL_HASH_PSFC = "hashPsfc";
 	public static final String DICTIONARY_TYPE_FOUR_SECTION_BIG ="dictionaryFourBig";
 
 	private DictionaryFactory() {}
@@ -67,7 +70,11 @@ public class DictionaryFactory {
 		String dictImpl = spec.get("tempDictionary.impl");
 		
 		// Implementations available in the Core
-		if(dictImpl==null || "".equals(dictImpl) || MOD_DICT_IMPL_HASH.equals(dictImpl)) {
+		if(dictImpl==null || "".equals(dictImpl) || MOD_DICT_IMPL_HASH_PSFC.equals(dictImpl)) {
+			return new PSFCTempDictionary(new HashDictionary(spec));
+		}
+
+		if(MOD_DICT_IMPL_HASH.equals(dictImpl)) {
 			return new HashDictionary(spec);
 		}
 		
@@ -77,7 +84,10 @@ public class DictionaryFactory {
 	
 	public static DictionaryPrivate createDictionary(HDTOptions spec) {
 		String name = spec.get("dictionary.type");
-		if(name==null || HDTVocabulary.DICTIONARY_TYPE_FOUR_SECTION.equals(name)) {
+		if(name==null || HDTVocabulary.DICTIONARY_TYPE_FOUR_PSFC_SECTION.equals(name)) {
+			return new PSFCFourSectionDictionary(spec);
+		}
+		else if (HDTVocabulary.DICTIONARY_TYPE_FOUR_SECTION.equals(name)){
 			return new FourSectionDictionary(spec);
 		}
 		else if (DICTIONARY_TYPE_FOUR_SECTION_BIG.equals(name)){
@@ -88,7 +98,10 @@ public class DictionaryFactory {
 	
 	public static DictionaryPrivate createDictionary(ControlInfo ci) {
 		String name = ci.getFormat();
-		if(HDTVocabulary.DICTIONARY_TYPE_FOUR_SECTION.equals(name)) {
+		if (HDTVocabulary.DICTIONARY_TYPE_FOUR_PSFC_SECTION.equals(name)) {
+			return new PSFCFourSectionDictionary(new HDTSpecification());
+		}
+		else if(HDTVocabulary.DICTIONARY_TYPE_FOUR_SECTION.equals(name)) {
 			return new FourSectionDictionary(new HDTSpecification());
 		}
 		throw new IllegalFormatException("Implementation of dictionary not found for "+name);

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/FourSectionDictionary.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/FourSectionDictionary.java
@@ -90,7 +90,7 @@ public class FourSectionDictionary extends BaseDictionary {
 	@Override
 	public void save(OutputStream output, ControlInfo ci, ProgressListener listener) throws IOException {
 		ci.setType(Type.DICTIONARY);
-		ci.setFormat(HDTVocabulary.DICTIONARY_TYPE_FOUR_SECTION);
+		ci.setFormat(getType());
 		ci.setInt("elements", this.getNumberOfElements());
 		ci.save(output);
 
@@ -143,7 +143,7 @@ public class FourSectionDictionary extends BaseDictionary {
 	 */
 	@Override
 	public void populateHeader(Header header, String rootNode) {
-		header.insert(rootNode, HDTVocabulary.DICTIONARY_TYPE, HDTVocabulary.DICTIONARY_TYPE_FOUR_SECTION);
+		header.insert(rootNode, HDTVocabulary.DICTIONARY_TYPE, getType());
 //		header.insert(rootNode, HDTVocabulary.DICTIONARY_NUMSUBJECTS, getNsubjects());
 //		header.insert(rootNode, HDTVocabulary.DICTIONARY_NUMPREDICATES, getNpredicates());
 //		header.insert(rootNode, HDTVocabulary.DICTIONARY_NUMOBJECTS, getNobjects());

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/PSFCFourSectionDictionary.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/PSFCFourSectionDictionary.java
@@ -1,0 +1,96 @@
+package org.rdfhdt.hdt.dictionary.impl;
+
+import org.rdfhdt.hdt.dictionary.TempDictionary;
+import org.rdfhdt.hdt.enums.TripleComponentRole;
+import org.rdfhdt.hdt.hdt.HDTVocabulary;
+import org.rdfhdt.hdt.listener.ProgressListener;
+import org.rdfhdt.hdt.options.HDTOptions;
+import org.rdfhdt.hdt.util.string.CompactString;
+import org.rdfhdt.hdt.util.string.DelayedString;
+import org.rdfhdt.hdt.util.string.ReplazableString;
+
+/**
+ * Prefix AND Suffix front-coded dictionary encodes strings so PFCDictionarySection will encode more efficiently
+ * than w/the standard NTriple uri/literal/blank node format.  Specifically, it moves the lang and datatype suffix
+ * for literals to the front of the string.
+ */
+public class PSFCFourSectionDictionary extends FourSectionDictionary {
+
+    public PSFCFourSectionDictionary(HDTOptions spec) {
+        super(spec);
+    }
+
+    static CharSequence encode(CharSequence str) {
+        // Example:
+        //   "123"^^<http://www.w3.org/2001/XMLSchema#integer>   is encoded to
+        //   ^^<http://www.w3.org/2001/XMLSchema#integer>"123"
+        CharSequence s = DelayedString.unwrap(str);
+        if (s == null || s.length() == 0 || s.charAt(0) != '"' || s.charAt(s.length() - 1) == '"') {
+            return str;
+        } else if (s instanceof CompactString) {
+            // Avoid UTF-8 encoder round trip
+            CompactString cs = (CompactString) s;
+            return swap(cs, cs.lastIndexOf('"') + 1);
+        } else {
+            String string = s.toString();
+            return swap(string, string.lastIndexOf('"') + 1);
+        }
+    }
+
+    static CharSequence decode(CharSequence str) {
+        // Example:
+        //   ^^<http://www.w3.org/2001/XMLSchema#integer>"123"   is decoded to
+        //   "123"^^<http://www.w3.org/2001/XMLSchema#integer>
+        CharSequence s = DelayedString.unwrap(str);
+        char ch;
+        if (s == null || s.length() == 0 || ((ch = s.charAt(0)) != '^' && ch != '@') || s.charAt(s.length() - 1) != '"') {
+            return str;
+        } else if (s instanceof CompactString) {
+            // Avoid UTF-8 encoder round trip
+            CompactString cs = (CompactString) s;
+            return swap(cs, cs.indexOf('"'));
+        } else {
+            String string = s.toString();
+            return swap(string, string.indexOf('"'));
+        }
+    }
+
+    @Override
+    public int stringToId(CharSequence str, TripleComponentRole position) {
+        return super.stringToId(encode(str), position);
+    }
+
+    @Override
+    public CharSequence idToString(int id, TripleComponentRole position) {
+        return decode(super.idToString(id, position));
+    }
+
+    @Override
+    public String getType() {
+        return HDTVocabulary.DICTIONARY_TYPE_FOUR_PSFC_SECTION;
+    }
+
+    @Override
+    public void load(TempDictionary other, ProgressListener listener) {
+        if (!(other instanceof PSFCTempDictionary)) {
+            throw new IllegalArgumentException("Expected " + PSFCTempDictionary.class.getName());
+        }
+        super.load(other, listener);
+    }
+
+    /** Given a compact string "[prefix][suffix]" where 'prefix' has length 'offset' returns "[suffix][prefix]". */
+    private static CharSequence swap(CompactString cs, int offset) {
+        ReplazableString buf = new ReplazableString(cs.length());
+        buf.append(cs.getData(), offset, cs.length() - offset);
+        buf.append(cs.getData(), 0, offset);
+        return new CompactString(buf).getDelayed();
+    }
+
+    /** Given a string string "[prefix][suffix]" where 'prefix' has length 'offset' returns "[suffix][prefix]". */
+    private static String swap(String string, int offset) {
+        StringBuilder buf = new StringBuilder(string.length());
+        buf.append(string, offset, string.length());
+        buf.append(string, 0, offset);
+        return buf.toString();
+    }
+}

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/PSFCTempDictionary.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/dictionary/impl/PSFCTempDictionary.java
@@ -1,0 +1,38 @@
+package org.rdfhdt.hdt.dictionary.impl;
+
+import org.rdfhdt.hdt.dictionary.TempDictionary;
+import org.rdfhdt.hdt.dictionary.TempDictionarySection;
+import org.rdfhdt.hdt.enums.TripleComponentRole;
+import org.rdfhdt.hdt.triples.TempTriples;
+
+import java.io.IOException;
+
+public class PSFCTempDictionary implements TempDictionary {
+    private final TempDictionary delegate;
+
+    public PSFCTempDictionary(TempDictionary delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public int stringToId(CharSequence subject, TripleComponentRole role) {
+        return delegate.stringToId(PSFCFourSectionDictionary.encode(subject), role);
+    }
+
+    @Override
+    public int insert(CharSequence str, TripleComponentRole position) {
+        return delegate.insert(PSFCFourSectionDictionary.encode(str), position);
+    }
+
+    @Override public TempDictionarySection getSubjects() { return delegate.getSubjects(); }
+    @Override public TempDictionarySection getPredicates() { return delegate.getPredicates(); }
+    @Override public TempDictionarySection getObjects() { return delegate.getObjects(); }
+    @Override public TempDictionarySection getShared() { return delegate.getShared(); }
+    @Override public void startProcessing() { delegate.startProcessing(); }
+    @Override public void endProcessing() { delegate.endProcessing(); }
+    @Override public boolean isOrganized() { return delegate.isOrganized(); }
+    @Override public void reorganize() { delegate.reorganize(); }
+    @Override public void reorganize(TempTriples triples) { delegate.reorganize(triples); }
+    @Override public void clear() { delegate.clear(); }
+    @Override public void close() throws IOException { delegate.close(); }
+}

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/string/CompactString.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/string/CompactString.java
@@ -77,6 +77,24 @@ public class CompactString implements CharSequence, Serializable, Comparable<Com
 		this.data = data;
 	}
 
+	public int indexOf(char ch) {
+		for (int i = 0; i < data.length; i++) {
+			if ((char) (data[i] & 0xff) == ch) {
+				return i;
+			}
+		}
+		return -1;
+	}
+
+	public int lastIndexOf(char ch) {
+		for (int i = data.length - 1; i >= 0; i--) {
+			if ((char) (data[i] & 0xff) == ch) {
+				return i;
+			}
+		}
+		return -1;
+	}
+
 	@Override
 	public char charAt(int index) {
 		int ix = index;

--- a/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/string/ReplazableString.java
+++ b/hdt-java-core/src/main/java/org/rdfhdt/hdt/util/string/ReplazableString.java
@@ -45,14 +45,16 @@ public final class ReplazableString implements CharSequence, Comparable<Replazab
 	
 	byte [] buffer;
 	int used;
-	/**
-	 * 
-	 */
+
 	public ReplazableString() {
-		buffer = new byte[128];
+		this(128);
+	}
+
+	public ReplazableString(int initialCapacity) {
+		buffer = new byte[initialCapacity];
 		used=0;
 	}
-	
+
 	private ReplazableString(byte [] buffer) {
 		this.buffer = buffer;
 		this.used = buffer.length;

--- a/hdt-java-core/src/test/java/org/rdfhdt/hdt/dictionary/impl/PSFCFourSectionDictionaryTest.java
+++ b/hdt-java-core/src/test/java/org/rdfhdt/hdt/dictionary/impl/PSFCFourSectionDictionaryTest.java
@@ -1,0 +1,81 @@
+package org.rdfhdt.hdt.dictionary.impl;
+
+import org.apache.jena.datatypes.xsd.XSDDatatype;
+import org.apache.jena.graph.NodeFactory;
+import org.junit.Test;
+import org.rdfhdt.hdt.rdf.parsers.JenaNodeFormatter;
+import org.rdfhdt.hdt.util.string.CompactString;
+import org.rdfhdt.hdt.util.string.DelayedString;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+public class PSFCFourSectionDictionaryTest {
+
+    @Test
+    public void testUri() {
+        doRoundTripNoop("http://example.com#s");
+    }
+
+    @Test
+    public void testBracketedUri() {
+        doRoundTripNoop("<http://example.com#s>");
+    }
+
+    @Test
+    public void testBlankNode() {
+        doRoundTripNoop("_:abc");
+    }
+
+    @Test
+    public void testPlainLiteral() {
+        doRoundTripNoop("\"abc\"");
+    }
+
+    @Test
+    public void testLocalizedLiteral() {
+        String literal = JenaNodeFormatter.format(NodeFactory.createLiteral("abc", "en"));
+        doRoundTrip(literal, "@en\"abc\"");
+    }
+
+    @Test
+    public void testTypedLiteral() {
+        String literal = JenaNodeFormatter.format(NodeFactory.createLiteral("123", XSDDatatype.XSDinteger));
+        doRoundTrip(literal, "^^<http://www.w3.org/2001/XMLSchema#integer>\"123\"");
+    }
+
+    private void doRoundTripNoop(String original) {
+        doRoundTrip(original, original);
+    }
+
+    private void doRoundTrip(String original, String expectedEncoded) {
+        doRoundTripString(original, expectedEncoded);
+        doRoundTripCompact(new CompactString(original), new CompactString(expectedEncoded));
+    }
+
+    private void doRoundTripString(String original, String expectedEncoded) {
+        String encoded = (String) PSFCFourSectionDictionary.encode(original);
+        assertEquals(expectedEncoded, encoded);
+
+        String decoded = (String) PSFCFourSectionDictionary.decode(encoded);
+        assertEquals(original, decoded);
+
+        // If encoding had no effect, we should have returned the original CharSequence object
+        if (original.equals(encoded)) {
+            assertSame(original, encoded);
+        }
+    }
+
+    private void doRoundTripCompact(CompactString original, CompactString expectedEncoded) {
+        CompactString encoded = (CompactString) DelayedString.unwrap(PSFCFourSectionDictionary.encode(original));
+        assertEquals(expectedEncoded, encoded);
+
+        CompactString decoded = (CompactString) DelayedString.unwrap(PSFCFourSectionDictionary.decode(encoded));
+        assertEquals(original, decoded);
+
+        // If encoding had no effect, we should have returned the original CharSequence object
+        if (original.equals(encoded)) {
+            assertSame(original, encoded);
+        }
+    }
+}


### PR DESCRIPTION
The HDT PFCDictionarySection class implements prefix front-coding to efficiently encode URIs with common prefixes. However, it is relatively inefficient at encoding typed literals like `"123"^^<http://www.w3.org/2001/XMLSchema#integer>`. To improve the encoding, this pull request encodes typed and localized literals by moving the type uri or language to the beginning of the string. For example:
```
"123"^^<http://www.w3.org/2001/XMLSchema#integer>
"abc"@en
```
is encoded as the following before being passed to the PFCDictionarySection:
```
^^<http://www.w3.org/2001/XMLSchema#integer>"123"
@en"abc"
```
For datasets with a lot of numbers, this can reduce the size of the resulting HDT file by as much as 50%. Because it's such a big difference, I've made it the default encoding, although old files should still be read correctly.